### PR TITLE
Adding an example of populating a Select field from an API

### DIFF
--- a/src/api-select/ApiSelect.tsx
+++ b/src/api-select/ApiSelect.tsx
@@ -1,0 +1,109 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { withCondition } from 'payload/components/forms';
+import {
+	useField,
+	SelectInput,
+} from "payload/components/forms";
+import { select } from 'payload/dist/fields/validations';
+import { Props } from 'payload/dist/admin/components/forms/field-types/Select/types';
+
+const ApiSelect: React.FC<Props> = (props) => {
+	const {
+		path: pathFromProps,
+		name,
+		validate = select,
+		label,
+		hasMany,
+		required,
+		loader,
+		admin: {
+			readOnly = false,
+			style = {},
+			className = '',
+			width = '100%',
+			description = '',
+			isClearable = true,
+			condition = null,
+			isSortable = false,
+		} = {},
+	} = props;
+
+	const path = pathFromProps || name;
+
+	const [options, setOptions] = useState([{ label: "Loading...", value: "" }]);
+
+	// Always default read only to true because the data is loaded as an effect
+	const [isReadOnly, setIsReadOnly] = useState(true);
+
+	useEffect(() => {
+		async function getData() {
+			setOptions(await loader());
+			setIsReadOnly(readOnly);
+		}
+
+		// Have to wrap the async function in this way because useEffect can't be async
+		getData();
+	}, []);
+
+	const memoizedValidate = useCallback((value, validationOptions) => {
+		return validate(value, { ...validationOptions, options, hasMany, required });
+	}, [validate, required, hasMany, options]);
+
+	const {
+		value,
+		showError,
+		setValue,
+		errorMessage,
+	} = useField({
+		path,
+		validate: memoizedValidate,
+		condition,
+	});
+
+	const onChange = useCallback((selectedOption) => {
+		if (!readOnly) {
+			let newValue;
+			if (!selectedOption) {
+				newValue = null;
+			} else if (hasMany) {
+				if (Array.isArray(selectedOption)) {
+					newValue = selectedOption.map((option) => option.value);
+				} else {
+					newValue = [];
+				}
+			} else {
+				newValue = selectedOption.value;
+			}
+
+			setValue(newValue);
+		}
+	}, [
+		readOnly,
+		hasMany,
+		setValue,
+	]);
+
+	return (
+		<SelectInput
+			path={path}
+			onChange={onChange}
+			value={value as string | string[]}
+			name={name}
+			options={options}
+			label={label}
+			showError={showError}
+			errorMessage={errorMessage}
+			required={required}
+			readOnly={isReadOnly}
+			description={description}
+			style={style}
+			className={className}
+			width={width}
+			hasMany={hasMany}
+			isSortable={isSortable}
+			isClearable={isClearable}
+		/>
+	);
+};
+
+export default withCondition(ApiSelect);

--- a/src/api-select/DogBreedApiSelect.tsx
+++ b/src/api-select/DogBreedApiSelect.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ApiSelect from "./ApiSelect";
+import GetDogBreeds from '../data/GetDogBreeds';
+
+const DogBreedApiSelect: typeof ApiSelect = (props) => {
+	return <ApiSelect {...props} loader={GetDogBreeds} />;
+}
+
+export default DogBreedApiSelect;

--- a/src/collections/Dogs.ts
+++ b/src/collections/Dogs.ts
@@ -1,0 +1,40 @@
+import { CollectionConfig } from 'payload/types';
+import DogBreedApiSelect from '../api-select/DogBreedApiSelect';
+
+const Dogs: CollectionConfig = {
+	slug: 'dog-metadata',
+	admin: {
+		useAsTitle: 'dogName',
+		defaultColumns: ['dogName', 'breed'],
+		group: 'Dogs',
+	},
+	fields: [
+		{
+			name: 'dogName',
+			label: 'Name',
+			type: 'text',
+			index: true,
+			required: true,
+		},
+		{
+			name: 'breed',
+			label: 'Breed',
+			type: 'text',
+			required: true,
+			admin: {
+				components: {
+					Field: DogBreedApiSelect,
+				},
+			},
+		},
+		{
+			name: 'SomeLovelyCompliments',
+			label: 'Some Lovely Compliments',
+			type: 'textarea',
+			required: true,
+			maxLength: 500,
+		}
+	],
+};
+
+export default Dogs;

--- a/src/data/GetDogBreeds.ts
+++ b/src/data/GetDogBreeds.ts
@@ -1,0 +1,23 @@
+export default async function (): Promise<{ label: string; value: string }[]> {
+	var data = await fetch(`https://dog.ceo/api/breeds/list/all`)
+		.then((res) => res.json())
+		.then((data) => {
+			const breeds = Object.keys(data.message);
+
+			return breeds.map((breed: string) => {
+				return {
+					label: breed,
+					value: breed
+				};
+			});
+		});
+
+	return data;
+}
+
+type DogBreeds = {
+	message: {
+		[breed: string]: string[] | string
+	}
+	status: string
+}

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -2,6 +2,7 @@ import { buildConfig } from 'payload/config';
 import path from 'path';
 // import Examples from './collections/Examples';
 import Users from './collections/Users';
+import Dogs from './collections/Dogs';
 
 export default buildConfig({
   serverURL: 'http://localhost:3161',
@@ -9,7 +10,7 @@ export default buildConfig({
     user: Users.slug,
   },
   collections: [
-    Users,
+    Users, Dogs
     // Add Collections here
     // Examples,
   ],


### PR DESCRIPTION
The collection is set up with a field type of `text`. This is then overridden using:
```
admin: {
    components: {
        Field: DogBreedApiSelect,
    },
},
```

`DogBreedApiSelect` is a wrapper around the `ApiSelect` custom field. It passes in the function supplied by the `GetDogBreeds` module (which is what queries the API and maps the data into a valid shape) as a prop called `loader`. `ApiSelect` then executes the `loader` and sets the options. This allows `ApiLoader` to be generic and execute any `loader` function.

`GetDogBreeds` could be getting the data from anywhere.

Things I'm not sure about:
* I'm sure my abstractions could be better.
* There's definitely more typing that could be done to make it more robust.
* I'm sure I can avoid the nesting of the promise code making the API call.

I'd love for there to be a way to just override the `useEffect` in `Select` so that I didn't have to duplicate the entire `Select` field.